### PR TITLE
Camelympics on staroid

### DIFF
--- a/.staroid/Dockerfile
+++ b/.staroid/Dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:18.04 AS builder
+
+# install jdk
+RUN apt-get -y update && \
+    apt-get install -y wget openjdk-8-jdk && \
+    rm -rf /var/lib/apt/lists/*
+
+# install maven
+RUN wget -q https://www-us.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz -P /tmp/ && \
+    tar xf /tmp/apache-maven-*.tar.gz -C /opt
+ENV PATH="/opt/apache-maven-3.6.3/bin:${PATH}"
+ENV MAVEN_CLI_OPTS="--no-transfer-progress"
+
+# build jar
+WORKDIR /camelympics
+COPY ./ /camelympics/
+RUN mvn compile assembly:single
+
+
+# container image
+FROM ubuntu:18.04
+
+RUN apt-get -y update && \
+    apt-get install -y curl openjdk-8-jre-headless && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /camelympics
+COPY --from=builder /camelympics/target/camelympics.jar /camelympics/
+
+# set non-root user
+USER 1000

--- a/.staroid/k8s-camelympics.yaml
+++ b/.staroid/k8s-camelympics.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: camelympics
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: camelympics
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: camelympics
+    spec:
+      containers:
+        - name: camelympics
+          image: camelympics
+          command:
+            - "bash"
+            - "-c"
+            - >-
+              java
+              -DconsumerKey=$consumerKey
+              -DconsumerSecret=$consumerSecret
+              -DaccessToken=$accessToken
+              -DaccessTokenSecret=$accessTokenSecret
+              -DsearchTerm=$searchTerm
+              -jar camelympics.jar
+          envFrom:
+            - configMapRef:
+                name: config
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "512Mi"
+            limits:
+              cpu: "1"
+              memory: "1024Mi"
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: camelympics
+spec:
+  ports:
+    - port: 8080
+  selector:
+    app.kubernetes.io/name: camelympics

--- a/.staroid/k8s-conf.yaml
+++ b/.staroid/k8s-conf.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config
+data:
+  consumerKey: ""
+  consumerSecret: ""
+  accessToken: ""
+  accessTokenSecret: ""
+  searchTerm: "sport"

--- a/.staroid/skaffold.yaml
+++ b/.staroid/skaffold.yaml
@@ -1,0 +1,19 @@
+# Staroid use skaffold for building container image and deploying k8s resources.
+# See https://skaffold.dev/docs/references/yaml/ for more details.
+#
+# To run locally, configure kubectl (with minikube or with your k8s cluster) and run
+#
+#   skaffold dev -f .staroid/skaffold.yaml --port-forward
+#
+apiVersion: skaffold/v2beta1
+kind: Config
+build:
+  artifacts:
+    - image: camelympics
+      context: .
+      docker:
+        dockerfile: .staroid/Dockerfile
+deploy:
+  kubectl:
+    manifests:
+      - .staroid/k8s-*.yaml

--- a/.staroid/staroid.yaml
+++ b/.staroid/staroid.yaml
@@ -1,0 +1,50 @@
+
+# This file instructs how to build and deploy the project on staroid.com.
+# See https://docs.staroid.com/references/staroid_yaml.html for more details.
+# You can use online validator https://staroid.com/site/validator to validate this yaml.
+apiVersion: beta/v1
+build:
+  skaffold:
+    file: .staroid/skaffold.yaml
+ingress:
+  - serviceName: camelympics
+    port: 8080
+deploy:
+  paramGroups:
+    - name: Configuration
+      collapsed: false
+      params:
+        - name: Search term
+          type: STRING
+          description: "Comma separated terms"
+          defaultValue: "sport,travel"
+          optional: false
+          paths:
+            - ConfigMap:config:data.searchTerm
+    - name: Twitter Access Token
+      collapsed: false
+      params:
+        - name: Consumer API key
+          type: STRING
+          defaultValue: ""
+          optional: false
+          paths:
+            - ConfigMap:config:data.consumerKey
+        - name: Consumer API secret key
+          type: STRING
+          defaultValue: ""
+          optional: false
+          paths:
+            - ConfigMap:config:data.consumerSecret
+        - name: Access token
+          type: STRING
+          defaultValue: ""
+          optional: false
+          paths:
+            - ConfigMap:config:data.accessToken
+        - name: Access token secret
+          type: STRING
+          defaultValue: ""
+          optional: false
+          paths:
+            - ConfigMap:config:data.accessTokenSecret

--- a/src/main/resources/web/index.html
+++ b/src/main/resources/web/index.html
@@ -32,7 +32,7 @@
     <link rel="stylesheet" href="css/screen.css" type="text/css" media="screen"/>
     <link rel="stylesheet" href="css/lightbox.css" type="text/css" media="screen"/>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
-    <link href='http://fonts.googleapis.com/css?family=Fredoka+One|Open+Sans:400,700' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Fredoka+One|Open+Sans:400,700' rel='stylesheet' type='text/css'>
 </head>
 <body>
 
@@ -118,7 +118,9 @@
     var app = {
         start:function () {
 //            var location = "ws://localhost:8080/camelympics";
-            var location = "ws://" + window.location.hostname + ":" + window.location.port + "/camelympics";
+
+            var proto = window.location.protocol == "https:" ? "wss" : "ws"
+            var location = proto + "://" + window.location.hostname + ":" + window.location.port + "/camelympics";
             this._ws = new WebSocket(location);
             this._ws.onmessage = this._onmessage;
             this._ws.onclose = this._onclose;


### PR DESCRIPTION
This pullrequest makes run camelympics on [staroid](https://staroid.com).

### Changes

 - `.staroid/Dockerfile` - for container image
 - `.staroid/skaffold.yaml` - to build container image and deploy Kubernetes resource files
 - `.staroid/k8s-camelympics.yaml` - Deployment and Service Kubernetes resources
 - `.staroid/k8s-conf.yaml` - Configuration (twitter api keys and search terms)
 - `.staroid/staroid.yaml` - staroid configuration with launch parameter

Also updates `src/main/resources/web/index.html` to support https protocol.

### local development

Setup [skaffold](https://skaffold.dev). Edit `.staroid/k8s-conf.yaml` and configure twitter api keys and search terms. and then run

```
skaffold dev -f .staroid/skaffold.yaml --port-forward
```

### Screen recoding

Here's a screen recording of launch, run, and check log messages through log console.

![edited](https://user-images.githubusercontent.com/1540981/85911913-503c3580-b7dd-11ea-94de-dd2a25f58d50.gif)
